### PR TITLE
bump mongoose to 5.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "isomorphic-unfetch": "^3.0.0",
     "jss": "^9.8.7",
     "lodash": "^4.17.10",
-    "mongoose": "^5.2.5",
+    "mongoose": "^5.7.3",
     "next": "^8.0.3",
     "react": "^16.8.3",
     "react-audio-player": "^0.11.0",


### PR DESCRIPTION
Bump mongoose to support MongoDB Cloud as part of DB porting